### PR TITLE
[ingress-nginx] Adjust pod affinity rules

### DIFF
--- a/charts/ingress-nginx/Chart.yaml
+++ b/charts/ingress-nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ingress-nginx
-version: 1.0.4
+version: 1.0.5
 description: Expose applications to the internet
 home: https://github.com/castai/official-addons
 sources:

--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -18,7 +18,17 @@ ingress-nginx:
                   operator: In
                   values:
                     - ingress-nginx
-            topologyKey: "topology.cast.ai/csp"
+            topologyKey: "kubernetes.io/hostname"
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - ingress-nginx
+              topologyKey: "topology.cast.ai/csp"
     metrics:
       enabled: true
       service:


### PR DESCRIPTION
1. Require to schedule on different hosts.
2. Prefer to schedule on multiple clouds in multi-cloud case only.

Replicas are automatically adjusted on cast smart system.